### PR TITLE
Fix issues with bootstrapping Windows nodes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,7 +70,7 @@ GROUP="Puppet Enterprise"
 # Number of Enterprise Linux managed nodes to create.
 EL_INSTANCES=1
 
-# Number of Windows 2012 
+# Number of Windows 2012
 WIN_INSTANCES=1
 
 # Domain for all nodes, i.e. "example.com". Defaults to "local" for support with
@@ -107,7 +107,7 @@ Vagrant.configure("2") do |config|
       v.name = "Puppet"
       v.memory = MEMORY_PUPPET
       v.cpus = CPU_PUPPET
-      v.customize [ 
+      v.customize [
         "modifyvm", :id,
         "--groups", "/#{GROUP}",
         "--ioapic", "on"
@@ -167,7 +167,7 @@ Vagrant.configure("2") do |config|
       SHELL
     end
   end
-  
+
   WIN_INSTANCES.times do |i|
     config.vm.define "win-node#{i}".to_sym do |winnode|
       winnode.vm.guest = :windows
@@ -191,7 +191,7 @@ Vagrant.configure("2") do |config|
       winnode.vm.provision :shell, path: "./scripts/Install-BonjourClient.ps1"
       winnode.vm.provision "shell" do |s|
         s.path = "./scripts/Install-PuppetEnterpriseAgent.ps1"
-        s.args = ["#{NAME_PUPPET}", "#{PE_WIN_AGENT}"]
+        s.args = ["#{NAME_PUPPET}.#{DOMAIN}", "#{PE_WIN_AGENT}"]
       end
     end
   end

--- a/scripts/Install-PuppetEnterpriseAgent.ps1
+++ b/scripts/Install-PuppetEnterpriseAgent.ps1
@@ -16,13 +16,15 @@
 param(
     [Parameter(Mandatory=$true)]
     [string]$PuppetMaster,
-    
+
     [Parameter(Mandatory=$true)]
     [string]$PuppetAgentInstaller
 )
 
+$AgentCertName = "$($env:computername.ToLower()).local"
+
 Write-Output "Puppet Master:          $PuppetMaster"
-Write-Output "Agent Cert Name:        $env:computername"
+Write-Output "Agent Cert Name:        $AgentCertName"
 Write-Output "Puppet Agent Installer: $PuppetAgentInstaller"
 
 #cmd.exe /C msiexec /qn /l* C:\vagrant\log\pe-agent-install.txt /i C:\vagrant\bin\puppet-enterprise-3.7.2-x64.msi PUPPET_MASTER_SERVER=$PuppetMaster PUPPET_AGENT_CERTNAME=$env:computername
@@ -47,7 +49,7 @@ if (!($PuppetInstalled)) {
   }
 
   # Install it - msiexec will download from the url
-  $install_args = @("/qn", "/norestart", "/i C:\vagrant\bin\$PuppetAgentInstaller", "PUPPET_MASTER_SERVER=$PuppetMaster", "PUPPET_AGENT_CERTNAME=$env:computername")
+  $install_args = @("/qn", "/norestart", "/i C:\vagrant\bin\$PuppetAgentInstaller", "PUPPET_MASTER_SERVER=$PuppetMaster", "PUPPET_AGENT_CERTNAME=$AgentCertName")
   Write-Host "Installing Puppet agent. Running msiexec.exe $install_args"
   $process = Start-Process -FilePath msiexec.exe -ArgumentList $install_args -Wait -PassThru
   if ($process.ExitCode -ne 0) {


### PR DESCRIPTION
Addresses an issue when provisioning Windows nodes and having them properly
request a signed Puppet certificate with a lowercase hostname.